### PR TITLE
Add import/extensions rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,12 @@ module.exports = {
       ],
       plugins: ['standard', 'flowtype', 'react', 'prettier', 'td'],
       rules: {
-        'td/no-ducks': 'error'
+        'td/no-ducks': 'error',
+        'import/extensions': [
+          'error',
+          'never',
+          { css: 'always', json: 'always' }
+        ]
       }
     }
   }


### PR DESCRIPTION
  Require no extension for .js files, require the extension for .css and .json files